### PR TITLE
support android build

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -2,8 +2,15 @@ all:	libnss.dummy
 
 ## NOTE: make must be serial because it breaks with parallel builds
 
+ifeq ($(CFG_OSTYPE),linux-androideabi)
+    export OS_TARGET = Android
+    export ANDROID_NDK = /opt/android-ndk
+    export OS_TARGET_RELEASE = 14
+else
+    export USE_64 = 1
+endif
+
 libnss.dummy:
-	USE_64=1 \
 	BUILD_TREE=`pwd` \
 	SOURCE_PREFIX=`pwd` \
 	NSPR_LIB_DIR=`pwd`/../nspr/dist/lib \


### PR DESCRIPTION
Support android build
This commit does not affect to each submodule's original standalone build system.
