### PR TITLE
Fix android build.

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -1,5 +1,5 @@
 TARGET=%TARGET%
-NDK_PATH=%NDK_PATH%
+NDK_TOOLCHAIN_PATH=%NDK_TOOLCHAIN_PATH%
 API_VER=%API_VER%
 SYS_BITS=%SYS_BITS%
 
@@ -12,10 +12,10 @@ libnss.dummy:
 	SOURCE_PREFIX=`pwd` \
 	NSPR_LIB_DIR=`pwd`/../nspr/dist/lib \
 	NSS_LIB_DIR=`pwd`/dist/lib \
-    ${TARGET} \
-    $(NDK_PATH) \
-    $(API_VER)\
-    $(SYS_BITS) \
+	${TARGET} \
+	$(NDK_TOOLCHAIN_PATH) \
+	$(API_VER)\
+	$(SYS_BITS) \
 	make -j1 -C %VPATH% all
 	touch libnss.dummy
 

--- a/configure
+++ b/configure
@@ -24,13 +24,13 @@ valopt() {
 }
 
 valopt host "" "Host triple"
-valopt android-ndk-path "/opt/android-ndk" "Android NDK path"
+valopt android-toolchain "/opt/android-ndk" "Android NDK toolchain path"
 valopt android-api-version 14 "Android API version"
 
 case ${CFG_HOST} in
     arm-linux-androideabi)
         TARGET=OS_TARGET=Android
-        NDK_PATH=ANDROID_NDK=${CFG_ANDROID_NDK_PATH}
+        NDK_TOOLCHAIN_PATH=ANDROID_TOOLCHAIN=${CFG_ANDROID_TOOLCHAIN}
         API_VER=OS_TARGET_RELEASE=${CFG_ANDROID_API_VERSION}
     ;;
     *)
@@ -38,4 +38,4 @@ case ${CFG_HOST} in
     ;;
 esac
 
-sed -e "s#%VPATH%#${SRCDIR}#g" -e "s#%TARGET%#${TARGET}#" -e "s#%NDK_PATH%#${NDK_PATH}#" -e "s#%API_VER%#${API_VER}#" -e "s#%SYS_BITS%#${SYS_BITS}#" ${SRCDIR}/Makefile.in > Makefile
+sed -e "s#%VPATH%#${SRCDIR}#g" -e "s#%TARGET%#${TARGET}#" -e "s#%NDK_TOOLCHAIN_PATH%#${NDK_TOOLCHAIN_PATH}#" -e "s#%API_VER%#${API_VER}#" -e "s#%SYS_BITS%#${SYS_BITS}#" ${SRCDIR}/Makefile.in > Makefile

--- a/coreconf/Linux.mk
+++ b/coreconf/Linux.mk
@@ -23,19 +23,19 @@ RANLIB			= ranlib
 DEFAULT_COMPILER = gcc
 
 ifeq ($(OS_TARGET),Android)
-ifndef ANDROID_NDK
-	$(error Must set ANDROID_NDK to the path to the android NDK first)
+ifndef ANDROID_TOOLCHAIN
+	$(error Must set ANDROID_TOOLCHAIN to the path to the android NDK toolchain first)
 endif
 	ANDROID_PREFIX=$(OS_TEST)-linux-androideabi
-	ANDROID_TARGET=$(ANDROID_PREFIX)-4.4.3
-	# should autodetect which linux we are on, currently android only
-	# supports linux-x86 prebuilts
-	ANDROID_TOOLCHAIN=$(ANDROID_NDK)/toolchains/$(ANDROID_TARGET)/prebuilt/linux-x86
-	ANDROID_SYSROOT=$(ANDROID_NDK)/platforms/android-$(OS_TARGET_RELEASE)/arch-$(OS_TEST)
+	ANDROID_SYSROOT=$(ANDROID_TOOLCHAIN)/sysroot
 	ANDROID_CC=$(ANDROID_TOOLCHAIN)/bin/$(ANDROID_PREFIX)-gcc
+	ANDROID_AR=$(ANDROID_TOOLCHAIN)/bin/$(ANDROID_PREFIX)-ar
+	ANDROID_RANLIB=$(ANDROID_TOOLCHAIN)/bin/$(ANDROID_PREFIX)-ranlib
 # internal tools need to be built with the native compiler
 ifndef INTERNAL_TOOLS
 	CC = $(ANDROID_CC) --sysroot=$(ANDROID_SYSROOT)
+	AR = $(ANDROID_AR) cr $@
+	RANLIB = $(ANDROID_RANLIB)
 	DEFAULT_COMPILER=$(ANDROID_PREFIX)-gcc
 	ARCHFLAG = --sysroot=$(ANDROID_SYSROOT)
 	DEFINES += -DNO_SYSINFO -DNO_FORK_CHECK -DANDROID
@@ -127,7 +127,7 @@ endif
 # Place -ansi and *_SOURCE before $(DSO_CFLAGS) so DSO_CFLAGS can override
 # -ansi on platforms like Android where the system headers are C99 and do
 # not build with -ansi.
-STANDARDS_CFLAGS	= -D_POSIX_SOURCE -D_BSD_SOURCE -D_XOPEN_SOURCE
+STANDARDS_CFLAGS	= -D_POSIX_SOURCE -D_POSIX_C_SOURCE=200112 -D_BSD_SOURCE -D_XOPEN_SOURCE -DHAVE_POSIX_FALLOCATE=0
 OS_CFLAGS		= $(STANDARDS_CFLAGS) $(DSO_CFLAGS) $(OS_REL_CFLAGS) $(ARCHFLAG) -Wall -Werror-implicit-function-declaration -Wno-switch -pipe -DLINUX -Dlinux -DHAVE_STRERROR
 OS_LIBS			= $(OS_PTHREAD) -ldl -lc
 


### PR DESCRIPTION
This fixes two isseus. The first is that NSS did not support building for
android from Darwin. Correcting the STANDARDS_CFLAGS and using the right `ar`
and `ranlib` addresses that issue.

The second issue is that the path to the toolchain was hardcoded to a version
that is no removed in recnet NDKs.

This is filed upstream as https://bugzilla.mozilla.org/show_bug.cgi?id=911240
