### PR TITLE
Fix secmod.h header define

### DIFF
--- a/lib/pk11wrap/secmod.h
+++ b/lib/pk11wrap/secmod.h
@@ -2,7 +2,7 @@
  * License, v. 2.0. If a copy of the MPL was not distributed with this
  * file, You can obtain one at http://mozilla.org/MPL/2.0/. */
 #ifndef _SECMOD_H_
-#define _SEDMOD_H_
+#define _SECMOD_H_
 #include "seccomon.h"
 #include "secmodt.h"
 #include "prinrval.h"


### PR DESCRIPTION
Before, this file could be included more than once causing errors due to the define statement in the header being wrong.
